### PR TITLE
feat: implement idempotency key contract (slice A)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@ Open-source PR review-to-fix loop automation for GitHub + CodeRabbit
 - `docs/finding-schema.md` — canonical deterministic finding schema and fingerprint formula
 - `docs/slice-b-ingest-handoff.md` — handoff contract for next ingest adapter slices
 - `docs/pr-summary-contract.md` — deterministic PR summary + baseline metrics contract
+- `docs/idempotency-contract.md` — deterministic idempotency-key contract + persistence adapter behavior

--- a/STATUS.md
+++ b/STATUS.md
@@ -2,3 +2,4 @@
 2026-03-27 | Rico | Issue #7 | Added first-pass GitHub+CodeRabbit ingest adapters, adapter fixtures, and adapter tests; test suite now 7 passing; posted corrected issue update | feature branch updated (54b8e0d)
 2026-03-27 | Rico | Issue #7 | Hardened threaded/suggested-change GitHub payload handling; added 2 edge-case tests; suite now 9 passing; posted issue progress correction | feature branch updated (8dc9abf)
 2026-03-28 | Rico | Issue #9 | Implemented deterministic PR summary renderer + baseline metrics + tests + contract doc; validated 12 tests; pushed commit | feature branch updated (8486059)
+2026-04-11 | Rico | Issue #12 | Implemented deterministic idempotency key contract + in-memory persistence adapter, added intake replay gate and tests, opened PR #16 | PR #16 open

--- a/STATUS.md
+++ b/STATUS.md
@@ -3,3 +3,4 @@
 2026-03-27 | Rico | Issue #7 | Hardened threaded/suggested-change GitHub payload handling; added 2 edge-case tests; suite now 9 passing; posted issue progress correction | feature branch updated (8dc9abf)
 2026-03-28 | Rico | Issue #9 | Implemented deterministic PR summary renderer + baseline metrics + tests + contract doc; validated 12 tests; pushed commit | feature branch updated (8486059)
 2026-04-11 | Rico | Issue #12 | Implemented deterministic idempotency key contract + in-memory persistence adapter, added intake replay gate and tests, opened PR #16 | PR #16 open
+2026-04-11 | Rico | Issue #12 | Addressed PR #16 review feedback: made idempotency write atomic and expanded key-source branch tests (camelCase/event_id/hash fallback) | PR #16 updated

--- a/STATUS.md
+++ b/STATUS.md
@@ -4,3 +4,4 @@
 2026-03-28 | Rico | Issue #9 | Implemented deterministic PR summary renderer + baseline metrics + tests + contract doc; validated 12 tests; pushed commit | feature branch updated (8486059)
 2026-04-11 | Rico | Issue #12 | Implemented deterministic idempotency key contract + in-memory persistence adapter, added intake replay gate and tests, opened PR #16 | PR #16 open
 2026-04-11 | Rico | Issue #12 | Addressed PR #16 review feedback: made idempotency write atomic and expanded key-source branch tests (camelCase/event_id/hash fallback) | PR #16 updated
+2026-04-11 | Rico | Issue #12 | Verified PR #16 is CLEAN with CodeRabbit success and 18/18 tests passing; marked slice complete for merge | status:done

--- a/docs/idempotency-contract.md
+++ b/docs/idempotency-contract.md
@@ -1,0 +1,35 @@
+# Idempotency Contract (Slice A)
+
+## Goal
+Prevent duplicate FindingDraft creation when the same inbound review event is replayed.
+
+## Normalization helper
+`src/idempotency.py::normalize_idempotency_key(payload)` applies deterministic normalization:
+
+1. Preferred keys (in order):
+   - `idempotency_key`
+   - `idempotencyKey`
+   - `event_id`
+2. If no explicit key exists, derive one from a canonical JSON SHA-256 hash of the payload.
+3. Final key is trimmed and lowercased.
+
+## Persistence adapter contract
+`IdempotencyStore` protocol:
+- `seen(key: str) -> bool`
+- `remember(key: str, fingerprint: str) -> None`
+
+First implementation: `InMemoryIdempotencyStore` for deterministic local tests.
+
+## FindingDraft ingest behavior
+`src/intake.py::ingest_finding_event(...)` behavior:
+- Normalize finding
+- Check idempotency key
+- **First write**: accepted (`True`) and finding persisted to `FindingDraftStore`
+- **Replay duplicate**: rejected (`False`) and no additional finding persisted
+
+## Test evidence
+`tests/test_idempotency.py` validates:
+- key normalization (`EVT-123` -> `evt-123`)
+- first-write acceptance
+- duplicate replay rejection
+- exactly one FindingDraft entry created for duplicate replays

--- a/src/idempotency.py
+++ b/src/idempotency.py
@@ -3,15 +3,14 @@ from __future__ import annotations
 import hashlib
 import json
 from dataclasses import dataclass
+from threading import Lock
 from typing import Any, Dict, Optional, Protocol
 
 
 class IdempotencyStore(Protocol):
     """Persistence adapter contract for idempotency keys."""
 
-    def seen(self, key: str) -> bool: ...
-
-    def remember(self, key: str, fingerprint: str) -> None: ...
+    def remember_if_absent(self, key: str, fingerprint: str) -> bool: ...
 
 
 @dataclass
@@ -19,15 +18,18 @@ class InMemoryIdempotencyStore:
     """Deterministic in-memory adapter for local tests/first implementation."""
 
     _keys: Dict[str, str]
+    _lock: Lock
 
     def __init__(self) -> None:
         self._keys = {}
+        self._lock = Lock()
 
-    def seen(self, key: str) -> bool:
-        return key in self._keys
-
-    def remember(self, key: str, fingerprint: str) -> None:
-        self._keys[key] = fingerprint
+    def remember_if_absent(self, key: str, fingerprint: str) -> bool:
+        with self._lock:
+            if key in self._keys:
+                return False
+            self._keys[key] = fingerprint
+            return True
 
 
 def _stable_payload_hash(payload: Dict[str, Any]) -> str:
@@ -51,7 +53,4 @@ def check_and_remember(
 ) -> bool:
     """Return True for first-write acceptance, False for duplicate replay rejection."""
     key = normalize_idempotency_key(payload)
-    if store.seen(key):
-        return False
-    store.remember(key, fingerprint or "")
-    return True
+    return store.remember_if_absent(key, fingerprint or "")

--- a/src/idempotency.py
+++ b/src/idempotency.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Protocol
+
+
+class IdempotencyStore(Protocol):
+    """Persistence adapter contract for idempotency keys."""
+
+    def seen(self, key: str) -> bool: ...
+
+    def remember(self, key: str, fingerprint: str) -> None: ...
+
+
+@dataclass
+class InMemoryIdempotencyStore:
+    """Deterministic in-memory adapter for local tests/first implementation."""
+
+    _keys: Dict[str, str]
+
+    def __init__(self) -> None:
+        self._keys = {}
+
+    def seen(self, key: str) -> bool:
+        return key in self._keys
+
+    def remember(self, key: str, fingerprint: str) -> None:
+        self._keys[key] = fingerprint
+
+
+def _stable_payload_hash(payload: Dict[str, Any]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def normalize_idempotency_key(payload: Dict[str, Any]) -> str:
+    """Normalize explicit keys, else derive one from deterministic payload hash."""
+    candidate = payload.get("idempotency_key") or payload.get("idempotencyKey") or payload.get("event_id")
+    if candidate is None:
+        candidate = _stable_payload_hash(payload)
+    return str(candidate).strip().lower()
+
+
+def check_and_remember(
+    payload: Dict[str, Any],
+    *,
+    store: IdempotencyStore,
+    fingerprint: Optional[str] = None,
+) -> bool:
+    """Return True for first-write acceptance, False for duplicate replay rejection."""
+    key = normalize_idempotency_key(payload)
+    if store.seen(key):
+        return False
+    store.remember(key, fingerprint or "")
+    return True

--- a/src/intake.py
+++ b/src/intake.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Protocol
+
+from src.idempotency import IdempotencyStore, check_and_remember
+from src.normalize import normalize_finding
+
+
+class FindingDraftStore(Protocol):
+    def add(self, finding: Dict[str, Any]) -> None: ...
+
+
+@dataclass
+class InMemoryFindingDraftStore:
+    findings: List[Dict[str, Any]]
+
+    def __init__(self) -> None:
+        self.findings = []
+
+    def add(self, finding: Dict[str, Any]) -> None:
+        self.findings.append(finding)
+
+
+def ingest_finding_event(
+    payload: Dict[str, Any],
+    *,
+    idempotency_store: IdempotencyStore,
+    finding_store: FindingDraftStore,
+) -> bool:
+    """Returns True when accepted/created, False when rejected as replay duplicate."""
+    finding = normalize_finding(payload)
+    accepted = check_and_remember(payload, store=idempotency_store, fingerprint=finding["fingerprint"])
+    if not accepted:
+        return False
+    finding_store.add(finding)
+    return True

--- a/tests/test_idempotency.py
+++ b/tests/test_idempotency.py
@@ -24,6 +24,31 @@ class TestIdempotencyContract(unittest.TestCase):
         payload = _sample_payload()
         self.assertEqual("evt-123", normalize_idempotency_key(payload))
 
+    def test_idempotency_key_camel_case_supported(self):
+        payload = _sample_payload()
+        payload.pop("idempotency_key")
+        payload["idempotencyKey"] = "EVT-CAMEL"
+        self.assertEqual("evt-camel", normalize_idempotency_key(payload))
+
+    def test_event_id_supported_when_key_missing(self):
+        payload = _sample_payload()
+        payload.pop("idempotency_key")
+        payload["event_id"] = "EVT-EVENT-ID"
+        self.assertEqual("evt-event-id", normalize_idempotency_key(payload))
+
+    def test_hash_fallback_deterministic_and_distinct(self):
+        payload_a = _sample_payload()
+        payload_a.pop("idempotency_key")
+        payload_b = dict(payload_a)
+        payload_b["message"] = "Changed payload"
+
+        key_a_1 = normalize_idempotency_key(payload_a)
+        key_a_2 = normalize_idempotency_key(dict(payload_a))
+        key_b = normalize_idempotency_key(payload_b)
+
+        self.assertEqual(key_a_1, key_a_2)
+        self.assertNotEqual(key_a_1, key_b)
+
     def test_first_write_accepted_and_duplicate_rejected(self):
         payload = _sample_payload()
         id_store = InMemoryIdempotencyStore()
@@ -34,6 +59,21 @@ class TestIdempotencyContract(unittest.TestCase):
 
         self.assertTrue(accepted_first)
         self.assertFalse(accepted_duplicate)
+        self.assertEqual(1, len(draft_store.findings))
+
+    def test_duplicate_rejected_when_event_id_is_key_source(self):
+        payload = _sample_payload()
+        payload.pop("idempotency_key")
+        payload["event_id"] = "evt-from-event-id"
+
+        id_store = InMemoryIdempotencyStore()
+        draft_store = InMemoryFindingDraftStore()
+
+        first = ingest_finding_event(payload, idempotency_store=id_store, finding_store=draft_store)
+        second = ingest_finding_event(dict(payload), idempotency_store=id_store, finding_store=draft_store)
+
+        self.assertTrue(first)
+        self.assertFalse(second)
         self.assertEqual(1, len(draft_store.findings))
 
 

--- a/tests/test_idempotency.py
+++ b/tests/test_idempotency.py
@@ -1,0 +1,41 @@
+import unittest
+
+from src.idempotency import InMemoryIdempotencyStore, normalize_idempotency_key
+from src.intake import InMemoryFindingDraftStore, ingest_finding_event
+
+
+def _sample_payload() -> dict:
+    return {
+        "source": "github_review",
+        "repo": "mendyraul/reviewpulse",
+        "prNumber": 42,
+        "path": "src/intake.py",
+        "lineStart": 10,
+        "lineEnd": 10,
+        "ruleId": "py.idempotency.001",
+        "severity": "medium",
+        "message": "Use deterministic idempotency handling",
+        "idempotency_key": "EVT-123",
+    }
+
+
+class TestIdempotencyContract(unittest.TestCase):
+    def test_idempotency_key_normalization(self):
+        payload = _sample_payload()
+        self.assertEqual("evt-123", normalize_idempotency_key(payload))
+
+    def test_first_write_accepted_and_duplicate_rejected(self):
+        payload = _sample_payload()
+        id_store = InMemoryIdempotencyStore()
+        draft_store = InMemoryFindingDraftStore()
+
+        accepted_first = ingest_finding_event(payload, idempotency_store=id_store, finding_store=draft_store)
+        accepted_duplicate = ingest_finding_event(payload, idempotency_store=id_store, finding_store=draft_store)
+
+        self.assertTrue(accepted_first)
+        self.assertFalse(accepted_duplicate)
+        self.assertEqual(1, len(draft_store.findings))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Implements Reliability Slice A (`#12`) by adding deterministic idempotency handling for inbound finding events.

## Changes
- Added `src/idempotency.py`:
  - `normalize_idempotency_key` helper (`idempotency_key`/`idempotencyKey`/`event_id` fallback to canonical payload hash)
  - `IdempotencyStore` protocol contract
  - `InMemoryIdempotencyStore` first persistence adapter
  - `check_and_remember` first-write/duplicate gate
- Added `src/intake.py`:
  - `FindingDraftStore` protocol
  - `InMemoryFindingDraftStore`
  - `ingest_finding_event` to enforce idempotency before persisting FindingDraft entries
- Added `tests/test_idempotency.py`:
  - key normalization assertion
  - first-write acceptance + duplicate replay rejection
  - verifies duplicate replay does not create additional FindingDraft entries
- Added docs in `docs/idempotency-contract.md`

## Validation
- `python3 -m unittest discover -s tests -q` (14 passing)

Closes #12


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Idempotency mechanism to detect and accept first-write finding events and reject duplicate replays.

* **Documentation**
  * Added an idempotency contract document describing key normalization, deterministic fingerprinting, and persistence expectations; status log entries recorded.

* **Tests**
  * Added contract tests for normalization rules, deterministic fallback hashing, first-write acceptance, and duplicate replay rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->