### PR TITLE
feat: implement Slice A Active Findings Board core logic

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -13,3 +13,4 @@
 2026-04-17 | Rico | Issue #19 | Closed issue as complete (DoD doc already delivered in PR #21); posted corrected closure comment after shell-escaping artifact | Closed
 2026-04-17 15:04 ET | Rico | Issue #4 | Queue-first fallback pass: decomposed epic into executable slices #24/#25/#26 and posted execution-order comment on parent | decomposition shipped
 2026-04-17 16:10 ET | Rico | Issue #24 | Implemented Active Findings Board core module (`src/active_findings_board.py`) with deterministic filtering/sorting, status-transition guardrails, URL filter encode/decode, and regression tests (`tests/test_active_findings_board.py`) | local implementation complete
+2026-04-17 17:12 ET | Rico | Issue #24 | Opened PR #27 and posted execution update on issue with validation proof (5 tests passing) | PR open

--- a/STATUS.md
+++ b/STATUS.md
@@ -2,3 +2,14 @@
 2026-03-27 | Rico | Issue #7 | Added first-pass GitHub+CodeRabbit ingest adapters, adapter fixtures, and adapter tests; test suite now 7 passing; posted corrected issue update | feature branch updated (54b8e0d)
 2026-03-27 | Rico | Issue #7 | Hardened threaded/suggested-change GitHub payload handling; added 2 edge-case tests; suite now 9 passing; posted issue progress correction | feature branch updated (8dc9abf)
 2026-03-28 | Rico | Issue #9 | Implemented deterministic PR summary renderer + baseline metrics + tests + contract doc; validated 12 tests; pushed commit | feature branch updated (8486059)
+
+2026-04-17 | Rico | Issue #20 | Authored done-state workflow UX spec and opened PR #22 (feature/issue-20-done-state) | PR #22 open
+
+2026-04-17 | Rico | Issue #18 | Revalidated PR risk summary UX spec artifact and posted queue-first lane2 execution update; commit/push pending public-repo approval | blocked (approval)
+2026-04-17 07:34 ET | Rico | Issue #18 | Authored PR risk summary UX spec doc, pushed branch, opened PR #23, commented on issue | PR open
+2026-04-17 08:34 ET | Rico | Issue #4 | Queue-first fallback orchestration pass: validated PR #21/#22/#23 merge readiness, posted parent closeout checklist + PR #23 sequencing note | coordination update posted
+2026-04-17 09:06 ET | Rico | Issue #18 | Merged PR #23 (risk summary UX spec), closed issue with completion comment | merged
+2026-04-17 10:04 ET | Rico | Issue #20 | Lane2 queue-fallback closeout: revalidated DoD against docs/ux/done-state-and-workflow.md + PR #22, posted corrected completion comment, closed issue #20 | closed
+2026-04-17 | Rico | Issue #19 | Closed issue as complete (DoD doc already delivered in PR #21); posted corrected closure comment after shell-escaping artifact | Closed
+2026-04-17 15:04 ET | Rico | Issue #4 | Queue-first fallback pass: decomposed epic into executable slices #24/#25/#26 and posted execution-order comment on parent | decomposition shipped
+2026-04-17 16:10 ET | Rico | Issue #24 | Implemented Active Findings Board core module (`src/active_findings_board.py`) with deterministic filtering/sorting, status-transition guardrails, URL filter encode/decode, and regression tests (`tests/test_active_findings_board.py`) | local implementation complete

--- a/docs/ux/done-state-and-workflow.md
+++ b/docs/ux/done-state-and-workflow.md
@@ -1,0 +1,165 @@
+# Done-State UX + Workflow Completion Model
+
+Issue: #20 (Parent: #4)
+
+## 1) Goal
+Define a deterministic “clear done” experience so users know when work is complete, what was completed, and what (if anything) still needs attention.
+
+This state should remove ambiguity at handoff time and keep confidence high when transitioning from active review to archive.
+
+---
+
+## 2) Workflow Stages (Canonical)
+
+Use one shared workflow model across dashboard surfaces:
+
+1. **Active Findings**
+   - Findings currently open and requiring owner action.
+   - Action-heavy view.
+2. **Resolved**
+   - Findings marked fixed/accepted and waiting for final verification window (if configured).
+   - Validation-focused view.
+3. **Archived**
+   - Findings that passed completion criteria and are no longer part of active throughput metrics.
+   - Historical/audit view.
+
+### Stage transition rules
+- `Active -> Resolved`
+  - Requires explicit owner action (`mark_resolved`) with timestamp + actor.
+- `Resolved -> Archived`
+  - Requires completion criteria pass (see section 3).
+- `Resolved -> Active`
+  - Allowed if regression/reopen signal arrives.
+- `Archived -> Active`
+  - Allowed for rare reopen cases with reason code (`regression`, `false_done`, `new_evidence`).
+
+---
+
+## 3) Done-State Criteria
+
+A workflow item is “done” when all criteria are true:
+
+- **No open blocking findings** in current scope.
+- **Completion confidence score >= threshold** (default 0.90).
+- **No pending owner assignment gaps** for current sprint window.
+- **No stale unresolved findings** older than SLA for critical/high severity.
+
+### Completion confidence (deterministic inputs)
+`completion_confidence` should be computed from:
+- closure ratio by severity (weighted),
+- unresolved stale count penalty,
+- recent reopen count penalty,
+- owner acknowledgement coverage.
+
+Output is a normalized float `0.00..1.00` with fixed rounding to 2 decimals in UI.
+
+---
+
+## 4) Done-State Messaging UX
+
+When criteria pass, show a prominent success panel:
+
+- **Title:** `Workflow complete`
+- **Primary message:** `All required findings are resolved and archived for this scope.`
+- **Subtext:** `Confidence: {completion_confidence} • Last verified {timestamp}`
+- **Actions:**
+  - `View archived findings`
+  - `Export completion summary`
+  - `Start new review cycle`
+
+When criteria do not pass, show exact blockers with deterministic reason codes.
+
+---
+
+## 5) KPI Widget Set (Completion + Throughput)
+
+Done-state view should include these top widgets:
+
+1. **Completion Confidence**
+   - Numeric badge + trend sparkline.
+2. **Cycle Throughput**
+   - Findings closed in selected time window.
+3. **Reopen Rate**
+   - `% reopened after resolve` (lower is better).
+4. **SLA Compliance**
+   - `% findings resolved within SLA by severity`.
+5. **Owner Coverage**
+   - `% findings with assigned and acknowledged owner`.
+
+All KPI widgets must share the same date-range filter and timezone basis.
+
+---
+
+## 6) Empty/No-Data Behavior
+
+### Empty state: no findings yet
+- Message: `No findings yet. Start a review run to populate this dashboard.`
+- CTA: `Run intake`
+
+### Empty resolved/archived state
+- Message: `No resolved findings in this range.`
+- CTA: `Expand date range`
+
+### API unavailable/error state
+- Message: `We couldn't load completion state right now.`
+- Include retry action and trace id.
+
+---
+
+## 7) Success/Failure Visual States
+
+### Success visual state
+- Green completion badge + check icon.
+- Timeline marker shows latest transition `Resolved -> Archived`.
+- KPI cards rendered with normal emphasis.
+
+### Failure/blocked visual state
+- Amber/red status pill based on blocker severity.
+- Blocker list rendered with reason code chips:
+  - `OPEN_BLOCKING_FINDINGS`
+  - `LOW_CONFIDENCE`
+  - `STALE_CRITICAL_FINDINGS`
+  - `OWNER_GAP`
+- Primary CTA routes user to exact filtered active list.
+
+---
+
+## 8) API/Contract Expectations (No Regression)
+
+No new API endpoints required for this UX slice.
+
+Expected payload fields (existing + additive-compatible):
+- `workflow_stage`
+- `completion_confidence`
+- `open_blocking_count`
+- `stale_critical_count`
+- `owner_coverage_ratio`
+- `reopen_rate`
+- `last_verified_at`
+- `blockers[]` (with reason codes)
+
+If a field is unavailable, UI must degrade gracefully with `N/A` and maintain layout stability.
+
+---
+
+## 9) QA Checklist
+
+- [ ] Stage transitions render correctly for Active/Resolved/Archived.
+- [ ] Done-state panel appears only when all criteria pass.
+- [ ] Blocked state lists deterministic reason codes.
+- [ ] KPI cards remain stable across empty and error states.
+- [ ] Date filter/timezone are applied consistently across all metrics.
+- [ ] Reopen transitions correctly move archived/resolved items back to active.
+- [ ] No regression in existing API calls (same endpoints continue to work).
+- [ ] Keyboard navigation reaches completion panel actions + blocker links.
+
+---
+
+## 10) Suggested Acceptance Test Scenarios
+
+1. **Happy path**: all findings resolved -> archived, confidence >= 0.90, done-state panel visible.
+2. **Low confidence**: all findings resolved but high reopen penalty -> blocked with `LOW_CONFIDENCE`.
+3. **Critical stale**: one unresolved critical over SLA -> blocked with `STALE_CRITICAL_FINDINGS`.
+4. **Owner gap**: unresolved owner coverage < threshold -> blocked with `OWNER_GAP`.
+5. **No data**: fresh workspace shows onboarding empty state and no crashes.
+6. **API error**: simulated backend failure shows retry+trace without breaking routing/navigation.

--- a/src/active_findings_board.py
+++ b/src/active_findings_board.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Dict, Iterable, List, Optional
+from urllib.parse import parse_qs, urlencode
+
+SEVERITY_ORDER = {"critical": 0, "high": 1, "medium": 2, "low": 3, "info": 4}
+ACTIVE_STATUSES = {"new", "triaged", "in_progress"}
+ALL_STATUSES = ACTIVE_STATUSES | {"resolved"}
+VALID_STATUS_TRANSITIONS = {
+    "new": {"triaged"},
+    "triaged": {"in_progress", "resolved"},
+    "in_progress": {"resolved", "triaged"},
+    "resolved": set(),
+}
+
+
+@dataclass(frozen=True)
+class BoardFilters:
+    severity: Optional[str] = None
+    owner: Optional[str] = None
+    status: Optional[str] = None
+    repo: Optional[str] = None
+
+
+def _parse_iso8601(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    return parsed.astimezone(timezone.utc)
+
+
+def compute_age_hours(first_seen_at: str, now: Optional[datetime] = None) -> float:
+    now_utc = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    first_seen = _parse_iso8601(first_seen_at)
+    seconds = max(0.0, (now_utc - first_seen).total_seconds())
+    return round(seconds / 3600.0, 2)
+
+
+def _matches_filters(finding: Dict, filters: BoardFilters) -> bool:
+    if filters.severity and finding.get("severity") != filters.severity:
+        return False
+    if filters.owner and finding.get("owner") != filters.owner:
+        return False
+    if filters.status and finding.get("status") != filters.status:
+        return False
+    if filters.repo and finding.get("repo") != filters.repo:
+        return False
+    return True
+
+
+def build_active_findings_board(
+    findings: Iterable[Dict],
+    filters: BoardFilters = BoardFilters(),
+    now: Optional[datetime] = None,
+) -> List[Dict]:
+    filtered: List[Dict] = []
+    for item in findings:
+        status = item.get("status", "new")
+        if status not in ACTIVE_STATUSES:
+            continue
+        if not _matches_filters(item, filters):
+            continue
+        enriched = dict(item)
+        enriched["ageHours"] = compute_age_hours(enriched["firstSeenAt"], now=now)
+        filtered.append(enriched)
+
+    return sorted(
+        filtered,
+        key=lambda f: (
+            SEVERITY_ORDER.get(f.get("severity", "info"), 99),
+            -f.get("ageHours", 0.0),
+            f.get("fingerprint", ""),
+        ),
+    )
+
+
+def transition_status(finding: Dict, target_status: str) -> Dict:
+    if target_status not in ALL_STATUSES:
+        raise ValueError(f"invalid_status:{target_status}")
+
+    current = finding.get("status", "new")
+    if current not in ALL_STATUSES:
+        raise ValueError(f"invalid_current_status:{current}")
+
+    allowed = VALID_STATUS_TRANSITIONS[current]
+    if target_status not in allowed:
+        raise ValueError(f"invalid_transition:{current}->{target_status}")
+
+    updated = dict(finding)
+    updated["status"] = target_status
+    if target_status == "resolved":
+        updated["resolvedAt"] = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    return updated
+
+
+def filters_to_query(filters: BoardFilters) -> str:
+    payload = {
+        "severity": filters.severity,
+        "owner": filters.owner,
+        "status": filters.status,
+        "repo": filters.repo,
+    }
+    compact = {k: v for k, v in payload.items() if v}
+    return urlencode(compact)
+
+
+def filters_from_query(query_string: str) -> BoardFilters:
+    parsed = parse_qs(query_string.lstrip("?"), keep_blank_values=False)
+
+    def first(name: str) -> Optional[str]:
+        values = parsed.get(name)
+        return values[0] if values else None
+
+    return BoardFilters(
+        severity=first("severity"),
+        owner=first("owner"),
+        status=first("status"),
+        repo=first("repo"),
+    )

--- a/tests/test_active_findings_board.py
+++ b/tests/test_active_findings_board.py
@@ -1,0 +1,84 @@
+import unittest
+from datetime import datetime, timezone
+
+from src.active_findings_board import (
+    BoardFilters,
+    build_active_findings_board,
+    filters_from_query,
+    filters_to_query,
+    transition_status,
+)
+
+
+class TestActiveFindingsBoard(unittest.TestCase):
+    def setUp(self):
+        self.now = datetime(2026, 4, 17, 20, 0, tzinfo=timezone.utc)
+        self.findings = [
+            {
+                "fingerprint": "a",
+                "severity": "high",
+                "status": "new",
+                "owner": "rico",
+                "repo": "mendyraul/reviewpulse",
+                "firstSeenAt": "2026-04-17T16:00:00Z",
+            },
+            {
+                "fingerprint": "b",
+                "severity": "critical",
+                "status": "triaged",
+                "owner": "sage",
+                "repo": "mendyraul/reviewpulse",
+                "firstSeenAt": "2026-04-17T12:00:00Z",
+            },
+            {
+                "fingerprint": "c",
+                "severity": "medium",
+                "status": "resolved",
+                "owner": "rico",
+                "repo": "mendyraul/reviewpulse",
+                "firstSeenAt": "2026-04-17T10:00:00Z",
+            },
+            {
+                "fingerprint": "d",
+                "severity": "critical",
+                "status": "in_progress",
+                "owner": "rico",
+                "repo": "mendyraul/TrackFlights",
+                "firstSeenAt": "2026-04-17T15:00:00Z",
+            },
+        ]
+
+    def test_board_includes_only_active_statuses_and_sorts_by_severity_then_age(self):
+        board = build_active_findings_board(self.findings, now=self.now)
+        self.assertEqual([f["fingerprint"] for f in board], ["b", "d", "a"])
+        self.assertEqual(board[0]["ageHours"], 8.0)
+
+    def test_board_filters_are_deterministic(self):
+        filters = BoardFilters(owner="rico", severity="critical")
+        board = build_active_findings_board(self.findings, filters=filters, now=self.now)
+        self.assertEqual([f["fingerprint"] for f in board], ["d"])
+
+    def test_valid_status_transition_updates_record(self):
+        finding = self.findings[0]
+        triaged = transition_status(finding, "triaged")
+        in_progress = transition_status(triaged, "in_progress")
+        resolved = transition_status(in_progress, "resolved")
+
+        self.assertEqual(triaged["status"], "triaged")
+        self.assertEqual(in_progress["status"], "in_progress")
+        self.assertEqual(resolved["status"], "resolved")
+        self.assertIn("resolvedAt", resolved)
+
+    def test_invalid_status_transition_raises(self):
+        with self.assertRaises(ValueError):
+            transition_status(self.findings[0], "resolved")
+
+    def test_filter_query_roundtrip(self):
+        filters = BoardFilters(severity="high", owner="rico", status="new", repo="mendyraul/reviewpulse")
+        query = filters_to_query(filters)
+        restored = filters_from_query(query)
+        self.assertEqual(restored, filters)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Implements issue #24 core Active Findings Board behavior as a deterministic module + tests.

## What changed
- Added `src/active_findings_board.py` with:
  - Active-only queue build (`new`, `triaged`, `in_progress`)
  - Deterministic filtering by severity, owner, status, repo
  - Priority sorting by severity then age
  - Guarded status transitions (`new -> triaged -> in_progress -> resolved`)
  - URL query encode/decode helpers for filter persistence
- Added `tests/test_active_findings_board.py` covering:
  - Active queue composition + sort order
  - Deterministic filtering behavior
  - Valid/invalid transition paths
  - Filter query roundtrip persistence

## Validation
- `python3 -m unittest tests/test_active_findings_board.py`

## Notes
This ships the backend/logic contract for Slice A so UI/API wiring can consume a stable implementation contract in follow-up slices.

Closes #24
