### PR TITLE
feat: implement Slice B PR risk summary panel logic

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,3 +2,4 @@
 2026-03-27 | Rico | Issue #7 | Added first-pass GitHub+CodeRabbit ingest adapters, adapter fixtures, and adapter tests; test suite now 7 passing; posted corrected issue update | feature branch updated (54b8e0d)
 2026-03-27 | Rico | Issue #7 | Hardened threaded/suggested-change GitHub payload handling; added 2 edge-case tests; suite now 9 passing; posted issue progress correction | feature branch updated (8dc9abf)
 2026-03-28 | Rico | Issue #9 | Implemented deterministic PR summary renderer + baseline metrics + tests + contract doc; validated 12 tests; pushed commit | feature branch updated (8486059)
+2026-04-17 18:14 ET | Rico | Issue #25 | Implemented deterministic PR risk summary engine (`src/pr_risk_summary.py`) + regression tests (`tests/test_pr_risk_summary.py`); validated full suite (17 tests passing) | local implementation complete

--- a/src/pr_risk_summary.py
+++ b/src/pr_risk_summary.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional
+from urllib.parse import urlencode
+
+
+WEIGHTS = {
+    "test_delta": 20,
+    "churn": 25,
+    "ownership_hotspot": 25,
+    "prior_defect_density": 30,
+}
+
+
+@dataclass(frozen=True)
+class RiskSignal:
+    name: str
+    score: int
+    evidence_url: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class RiskSummary:
+    risk_score: int
+    confidence: str
+    recommendation: str
+    top_drivers: List[RiskSignal]
+
+
+def _clamp(value: int, low: int = 0, high: int = 100) -> int:
+    return max(low, min(high, value))
+
+
+def compute_risk_score(signals: Dict[str, int]) -> int:
+    weighted_sum = 0.0
+    weight_total = 0
+    for key, weight in WEIGHTS.items():
+        raw = int(signals.get(key, 0))
+        weighted_sum += _clamp(raw) * weight
+        weight_total += weight
+
+    if weight_total == 0:
+        return 0
+
+    return int(round(weighted_sum / weight_total))
+
+
+def score_to_confidence(risk_score: int) -> str:
+    if risk_score <= 25:
+        return "high"
+    if risk_score <= 60:
+        return "medium"
+    return "low"
+
+
+def recommendation_for_score(risk_score: int) -> str:
+    if risk_score <= 30:
+        return "safe_to_merge"
+    if risk_score <= 70:
+        return "review_required"
+    return "block_pending"
+
+
+def build_risk_summary(
+    signals: Dict[str, int],
+    evidence_by_signal: Optional[Dict[str, str]] = None,
+    top_n: int = 3,
+) -> RiskSummary:
+    evidence_by_signal = evidence_by_signal or {}
+    normalized: List[RiskSignal] = [
+        RiskSignal(name=name, score=_clamp(int(signals.get(name, 0))), evidence_url=evidence_by_signal.get(name))
+        for name in WEIGHTS.keys()
+    ]
+    top_drivers = sorted(normalized, key=lambda s: (-s.score, s.name))[:top_n]
+
+    risk_score = compute_risk_score(signals)
+    confidence = score_to_confidence(risk_score)
+    recommendation = recommendation_for_score(risk_score)
+
+    return RiskSummary(
+        risk_score=risk_score,
+        confidence=confidence,
+        recommendation=recommendation,
+        top_drivers=top_drivers,
+    )
+
+
+def evidence_link(pr_number: int, signal_name: str) -> str:
+    return f"/evidence?{urlencode({'pr': pr_number, 'signal': signal_name})}"
+
+
+def summarize_pr_row(pr: Dict) -> Dict:
+    pr_number = int(pr["number"])
+    signals = pr.get("signals", {})
+    summary = build_risk_summary(
+        signals,
+        evidence_by_signal={name: evidence_link(pr_number, name) for name in WEIGHTS.keys()},
+    )
+
+    return {
+        "prNumber": pr_number,
+        "title": pr.get("title", ""),
+        "riskScore": summary.risk_score,
+        "confidence": summary.confidence,
+        "recommendation": summary.recommendation,
+        "topDrivers": [
+            {
+                "signal": signal.name,
+                "score": signal.score,
+                "evidenceUrl": signal.evidence_url,
+            }
+            for signal in summary.top_drivers
+        ],
+    }

--- a/tests/test_pr_risk_summary.py
+++ b/tests/test_pr_risk_summary.py
@@ -1,0 +1,74 @@
+import unittest
+
+from src.pr_risk_summary import (
+    build_risk_summary,
+    compute_risk_score,
+    recommendation_for_score,
+    score_to_confidence,
+    summarize_pr_row,
+)
+
+
+class TestPrRiskSummary(unittest.TestCase):
+    def test_weighted_risk_score_is_deterministic(self):
+        score = compute_risk_score(
+            {
+                "test_delta": 80,
+                "churn": 40,
+                "ownership_hotspot": 30,
+                "prior_defect_density": 90,
+            }
+        )
+        self.assertEqual(score, 60)
+
+    def test_recommendation_bands(self):
+        self.assertEqual(recommendation_for_score(20), "safe_to_merge")
+        self.assertEqual(recommendation_for_score(50), "review_required")
+        self.assertEqual(recommendation_for_score(88), "block_pending")
+
+    def test_confidence_bands(self):
+        self.assertEqual(score_to_confidence(20), "high")
+        self.assertEqual(score_to_confidence(55), "medium")
+        self.assertEqual(score_to_confidence(80), "low")
+
+    def test_summary_returns_top_drivers_with_evidence_links(self):
+        summary = build_risk_summary(
+            {
+                "test_delta": 70,
+                "churn": 90,
+                "ownership_hotspot": 85,
+                "prior_defect_density": 65,
+            },
+            evidence_by_signal={
+                "churn": "/evidence?pr=12&signal=churn",
+                "ownership_hotspot": "/evidence?pr=12&signal=ownership_hotspot",
+                "test_delta": "/evidence?pr=12&signal=test_delta",
+            },
+        )
+
+        self.assertEqual(summary.recommendation, "block_pending")
+        self.assertEqual([d.name for d in summary.top_drivers], ["churn", "ownership_hotspot", "test_delta"])
+        self.assertEqual(summary.top_drivers[0].evidence_url, "/evidence?pr=12&signal=churn")
+
+    def test_summarize_pr_row_shape(self):
+        row = summarize_pr_row(
+            {
+                "number": 42,
+                "title": "Reduce flaky test retries",
+                "signals": {
+                    "test_delta": 20,
+                    "churn": 10,
+                    "ownership_hotspot": 10,
+                    "prior_defect_density": 5,
+                },
+            }
+        )
+
+        self.assertEqual(row["prNumber"], 42)
+        self.assertEqual(row["recommendation"], "safe_to_merge")
+        self.assertEqual(len(row["topDrivers"]), 3)
+        self.assertTrue(row["topDrivers"][0]["evidenceUrl"].startswith("/evidence?pr=42"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Implements Slice B deterministic PR Risk Summary logic contract for dashboard integration.

## What changed
- Added `src/pr_risk_summary.py` with:
  - weighted deterministic risk score from test delta/churn/ownership hotspot/prior defect density
  - confidence indicator bands (`high`/`medium`/`low`)
  - recommendation state derivation (`safe_to_merge` / `review_required` / `block_pending`)
  - top-driver extraction with stable ordering
  - evidence-link helper and row serializer for PR card/table rendering
- Added `tests/test_pr_risk_summary.py` covering:
  - deterministic score calculation
  - recommendation and confidence band mapping
  - top-driver ordering + evidence URL propagation
  - serialized row shape for UI consumption
- Updated `STATUS.md` with Issue #25 execution log entry.

## Validation
- `python3 -m unittest discover -s tests -p 'test_*.py'` (17 passed)

Closes #25


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a PR risk summary engine that calculates risk scores with confidence tiers (high/medium/low) and merge recommendations (safe_to_merge/review_required/block_pending).
  * Ranks and displays top risk drivers with evidence links for each pull request.

* **Tests**
  * Implemented comprehensive test suite with 17 passing tests validating risk scoring consistency, recommendation mapping, and output structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->