### PR TITLE
feat: owner routing visibility + done-state workflow primitives

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,3 +2,4 @@
 2026-03-27 | Rico | Issue #7 | Added first-pass GitHub+CodeRabbit ingest adapters, adapter fixtures, and adapter tests; test suite now 7 passing; posted corrected issue update | feature branch updated (54b8e0d)
 2026-03-27 | Rico | Issue #7 | Hardened threaded/suggested-change GitHub payload handling; added 2 edge-case tests; suite now 9 passing; posted issue progress correction | feature branch updated (8dc9abf)
 2026-03-28 | Rico | Issue #9 | Implemented deterministic PR summary renderer + baseline metrics + tests + contract doc; validated 12 tests; pushed commit | feature branch updated (8486059)
+2026-04-17 | Rico | Issue #26 | Added owner-routing board domain logic (owner/escalation/SLA enrichment, deterministic filters, status transitions, archive split) with full unit test coverage | feature branch updated

--- a/src/board.py
+++ b/src/board.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Optional
+
+ACTIVE_STATUSES = {"new", "triaged", "in_progress"}
+DONE_STATUSES = {"resolved", "archived"}
+ALLOWED_TRANSITIONS = {
+    "new": {"triaged"},
+    "triaged": {"in_progress", "resolved"},
+    "in_progress": {"resolved"},
+    "resolved": {"archived"},
+    "archived": set(),
+}
+
+
+def _parse_iso(ts: Optional[str]) -> Optional[datetime]:
+    if not ts:
+        return None
+    try:
+        return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _age_hours(first_seen_at: Optional[str], now: datetime) -> Optional[float]:
+    seen = _parse_iso(first_seen_at)
+    if not seen:
+        return None
+    if seen.tzinfo is None:
+        seen = seen.replace(tzinfo=timezone.utc)
+    return round((now - seen).total_seconds() / 3600, 2)
+
+
+def enrich_findings(
+    findings: Iterable[Dict[str, Any]],
+    *,
+    now_iso: Optional[str] = None,
+    stale_after_hours: int = 24,
+) -> List[Dict[str, Any]]:
+    now = _parse_iso(now_iso) if now_iso else datetime.now(tz=timezone.utc)
+    if now is None:
+        now = datetime.now(tz=timezone.utc)
+
+    enriched: List[Dict[str, Any]] = []
+    for finding in findings:
+        row = dict(finding)
+        status = str(row.get("status", "new")).lower()
+        age = _age_hours(row.get("firstSeenAt"), now)
+
+        owner = row.get("owner")
+        escalation = row.get("escalation") or "none"
+        unassigned = owner in (None, "", "unassigned")
+
+        stale = status in ACTIVE_STATUSES and age is not None and age >= stale_after_hours
+        row.update(
+            {
+                "status": status,
+                "owner": "unassigned" if unassigned else owner,
+                "escalation": escalation,
+                "ageHours": age,
+                "isStale": stale,
+                "sla": "breached" if stale else "ok",
+                "doneState": status in DONE_STATUSES,
+            }
+        )
+        enriched.append(row)
+
+    return enriched
+
+
+def filter_findings(
+    findings: Iterable[Dict[str, Any]],
+    *,
+    severity: Optional[str] = None,
+    owner: Optional[str] = None,
+    status: Optional[str] = None,
+    repo: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    rows = list(findings)
+
+    def _matches(row: Dict[str, Any]) -> bool:
+        if severity and str(row.get("severity", "")).lower() != severity.lower():
+            return False
+        if owner and str(row.get("owner", "")).lower() != owner.lower():
+            return False
+        if status and str(row.get("status", "")).lower() != status.lower():
+            return False
+        if repo and str(row.get("repo", "")).lower() != repo.lower():
+            return False
+        return True
+
+    return [row for row in rows if _matches(row)]
+
+
+def transition_status(
+    finding: Dict[str, Any],
+    to_status: str,
+    *,
+    actor: str,
+    at_iso: str,
+) -> Dict[str, Any]:
+    row = dict(finding)
+    from_status = str(row.get("status", "new")).lower()
+    to_status = to_status.lower()
+
+    allowed = ALLOWED_TRANSITIONS.get(from_status, set())
+    if to_status not in allowed:
+        raise ValueError(f"invalid transition: {from_status} -> {to_status}")
+
+    timeline = list(row.get("timeline", []))
+    timeline.append(
+        {
+            "event": "status_transition",
+            "from": from_status,
+            "to": to_status,
+            "actor": actor,
+            "at": at_iso,
+        }
+    )
+
+    row["status"] = to_status
+    row["timeline"] = timeline
+    if to_status == "resolved":
+        row["resolvedAt"] = at_iso
+    if to_status == "archived":
+        row["archivedAt"] = at_iso
+    return row
+
+
+def split_active_and_archive(findings: Iterable[Dict[str, Any]]) -> Dict[str, List[Dict[str, Any]]]:
+    active: List[Dict[str, Any]] = []
+    archive: List[Dict[str, Any]] = []
+    for row in findings:
+        status = str(row.get("status", "new")).lower()
+        if status == "archived":
+            archive.append(row)
+        else:
+            active.append(row)
+    return {"active": active, "archive": archive}

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -1,0 +1,89 @@
+import unittest
+
+from src.board import enrich_findings, filter_findings, split_active_and_archive, transition_status
+
+
+class TestBoard(unittest.TestCase):
+    def setUp(self):
+        self.rows = [
+            {
+                "fingerprint": "a",
+                "repo": "mendyraul/reviewpulse",
+                "severity": "high",
+                "status": "new",
+                "owner": "rico",
+                "firstSeenAt": "2026-04-17T00:00:00Z",
+            },
+            {
+                "fingerprint": "b",
+                "repo": "mendyraul/reviewpulse",
+                "severity": "medium",
+                "status": "triaged",
+                "owner": "",
+                "firstSeenAt": "2026-04-18T11:00:00Z",
+            },
+            {
+                "fingerprint": "c",
+                "repo": "mendyraul/other",
+                "severity": "low",
+                "status": "resolved",
+                "owner": "sage",
+                "firstSeenAt": "2026-04-16T10:00:00Z",
+            },
+        ]
+
+    def test_enrich_adds_owner_escalation_age_and_sla(self):
+        enriched = enrich_findings(self.rows, now_iso="2026-04-18T12:00:00Z", stale_after_hours=24)
+
+        first = enriched[0]
+        self.assertEqual(first["owner"], "rico")
+        self.assertEqual(first["escalation"], "none")
+        self.assertTrue(first["isStale"])
+        self.assertEqual(first["sla"], "breached")
+
+        second = enriched[1]
+        self.assertEqual(second["owner"], "unassigned")
+        self.assertFalse(second["isStale"])
+
+        third = enriched[2]
+        self.assertTrue(third["doneState"])
+
+    def test_filters_are_deterministic(self):
+        enriched = enrich_findings(self.rows, now_iso="2026-04-18T12:00:00Z")
+        filtered = filter_findings(enriched, severity="high", owner="rico", status="new", repo="mendyraul/reviewpulse")
+        self.assertEqual(len(filtered), 1)
+        self.assertEqual(filtered[0]["fingerprint"], "a")
+
+    def test_status_transition_and_timeline(self):
+        finding = {"status": "triaged", "timeline": []}
+        updated = transition_status(
+            finding,
+            "in_progress",
+            actor="rico",
+            at_iso="2026-04-18T12:30:00Z",
+        )
+        self.assertEqual(updated["status"], "in_progress")
+        self.assertEqual(len(updated["timeline"]), 1)
+        self.assertEqual(updated["timeline"][0]["from"], "triaged")
+
+    def test_invalid_transition_raises(self):
+        with self.assertRaises(ValueError):
+            transition_status(
+                {"status": "new"},
+                "resolved",
+                actor="rico",
+                at_iso="2026-04-18T12:30:00Z",
+            )
+
+    def test_archive_split(self):
+        rows = [
+            {"fingerprint": "x", "status": "in_progress"},
+            {"fingerprint": "y", "status": "archived"},
+        ]
+        split = split_active_and_archive(rows)
+        self.assertEqual(len(split["active"]), 1)
+        self.assertEqual(len(split["archive"]), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary\n- add board domain primitives for owner/escalation visibility and stale/SLA tagging\n- add deterministic filtering helper for severity/owner/status/repo\n- add strict lifecycle transition helper + timeline event recording\n- add active/archive split helper for done-state UX\n- cover all new behavior with unit tests\n\n## Testing\n- python -m unittest discover -s tests -p 'test_*.py'\n\nFixes #26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added findings management capabilities with status transitions and validation rules
  * Introduced advanced filtering by severity, owner, status, and repository
  * Automatic enrichment of findings with computed metadata (age, SLA status, escalation level)
  * Added archive functionality to separate completed findings from active ones

* **Tests**
  * Added comprehensive test coverage for findings management operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->