### PR TITLE
feat: PR risk summary panel metrics with 7d/30d windows

### DIFF
--- a/src/dashboard_risk_summary.py
+++ b/src/dashboard_risk_summary.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Dict, Iterable, List, Optional
+from urllib.parse import urlencode
+
+from src.pr_risk_summary import summarize_pr_row
+
+
+@dataclass(frozen=True)
+class TimeWindow:
+    key: str
+    days: int
+
+
+WINDOWS = {
+    "7d": TimeWindow(key="7d", days=7),
+    "30d": TimeWindow(key="30d", days=30),
+}
+
+
+def _parse_iso(ts: str) -> datetime:
+    return datetime.fromisoformat(ts.replace("Z", "+00:00")).astimezone(timezone.utc)
+
+
+def _window_cutoff(window: str, now: Optional[datetime] = None) -> datetime:
+    selected = WINDOWS.get(window)
+    if not selected:
+        raise ValueError(f"invalid_window:{window}")
+    now_utc = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    return now_utc - timedelta(days=selected.days)
+
+
+def _high_risk(score: int) -> bool:
+    return score > 70
+
+
+def build_pr_risk_summary_panel(pr_rows: Iterable[Dict], window: str = "7d", now: Optional[datetime] = None) -> Dict:
+    cutoff = _window_cutoff(window, now=now)
+    rows = [row for row in pr_rows if _parse_iso(row["updatedAt"]) >= cutoff]
+
+    summaries = [summarize_pr_row(row) for row in rows]
+    high_risk = [s for s in summaries if _high_risk(s["riskScore"])]
+
+    repo_counts = Counter(str(row.get("repo", "")) for row in rows if row.get("repo"))
+    hot_repositories = [
+        {"repo": name, "count": count, "url": f"/dashboard/findings?{urlencode({'repo': name, 'window': window})}"}
+        for name, count in sorted(repo_counts.items(), key=lambda item: (-item[1], item[0]))[:3]
+    ]
+
+    previous_cutoff_start = cutoff - (datetime.now(timezone.utc) - cutoff if now is None else (now - cutoff))
+    previous_rows = [
+        row for row in pr_rows if previous_cutoff_start <= _parse_iso(row["updatedAt"]) < cutoff
+    ]
+    previous_high_risk = len([1 for row in previous_rows if _high_risk(summarize_pr_row(row)["riskScore"])])
+
+    trend = len(high_risk) - previous_high_risk
+
+    return {
+        "window": window,
+        "highRiskPrCount": len(high_risk),
+        "highRiskPrUrl": f"/dashboard/prs?{urlencode({'risk': 'high', 'window': window})}",
+        "trend": {
+            "delta": trend,
+            "direction": "up" if trend > 0 else "down" if trend < 0 else "flat",
+            "url": f"/dashboard/prs?{urlencode({'metric': 'trend', 'window': window})}",
+        },
+        "hotRepositories": hot_repositories,
+    }

--- a/tests/test_dashboard_risk_summary.py
+++ b/tests/test_dashboard_risk_summary.py
@@ -1,0 +1,47 @@
+import unittest
+from datetime import datetime, timezone
+
+from src.dashboard_risk_summary import build_pr_risk_summary_panel
+
+
+class TestDashboardRiskSummary(unittest.TestCase):
+    def setUp(self):
+        self.now = datetime(2026, 5, 13, 10, 0, tzinfo=timezone.utc)
+        self.rows = [
+            {
+                "number": 101,
+                "title": "Safe cleanup",
+                "repo": "mendyraul/reviewpulse",
+                "updatedAt": "2026-05-12T10:00:00Z",
+                "signals": {"test_delta": 10, "churn": 15, "ownership_hotspot": 20, "prior_defect_density": 10},
+            },
+            {
+                "number": 102,
+                "title": "Risky migration",
+                "repo": "mendyraul/reviewpulse",
+                "updatedAt": "2026-05-11T10:00:00Z",
+                "signals": {"test_delta": 80, "churn": 90, "ownership_hotspot": 70, "prior_defect_density": 95},
+            },
+            {
+                "number": 103,
+                "title": "Risky infra",
+                "repo": "mendyraul/TrackFlights",
+                "updatedAt": "2026-05-08T10:00:00Z",
+                "signals": {"test_delta": 75, "churn": 75, "ownership_hotspot": 80, "prior_defect_density": 80},
+            },
+        ]
+
+    def test_panel_metrics_with_7d_window(self):
+        panel = build_pr_risk_summary_panel(self.rows, window="7d", now=self.now)
+        self.assertEqual(panel["window"], "7d")
+        self.assertEqual(panel["highRiskPrCount"], 2)
+        self.assertEqual(panel["trend"]["direction"], "up")
+        self.assertEqual(panel["hotRepositories"][0]["repo"], "mendyraul/reviewpulse")
+
+    def test_invalid_window_raises(self):
+        with self.assertRaises(ValueError):
+            build_pr_risk_summary_panel(self.rows, window="14d", now=self.now)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements issue #32.

## What shipped
- Added build_pr_risk_summary_panel to compute dashboard metrics from existing PR risk model.
- Supports 7d and 30d time windows.
- Exposes drill-down links for high-risk count, trend, and hot repositories.
- Added deterministic unit tests for summary behavior and window validation.

## Validation
- python -m unittest discover -s tests -p 'test_*.py'