### PR TITLE
feat: add PR risk summary dashboard metrics

### DIFF
--- a/src/dashboard_risk_panel.py
+++ b/src/dashboard_risk_panel.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from collections import Counter
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Iterable, List
+from urllib.parse import urlencode
+
+from src.pr_risk_summary import summarize_pr_row
+
+
+def _parse_iso(ts: str | None) -> datetime | None:
+    if not ts:
+        return None
+    try:
+        return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _window_start(days: int, now: datetime | None = None) -> datetime:
+    now = now or datetime.now(timezone.utc)
+    return now - timedelta(days=days)
+
+
+def _filter_window(pr_rows: Iterable[Dict[str, Any]], days: int, now: datetime | None = None) -> List[Dict[str, Any]]:
+    start = _window_start(days, now=now)
+    out: List[Dict[str, Any]] = []
+    for row in pr_rows:
+        merged = _parse_iso(row.get("mergedAt"))
+        if merged and merged >= start:
+            out.append(row)
+    return out
+
+
+def _link(path: str, **params: Any) -> str:
+    return f"/{path}?{urlencode(params)}"
+
+
+def build_pr_risk_dashboard(pr_rows: Iterable[Dict[str, Any]], window: str = "7d", now: datetime | None = None) -> Dict[str, Any]:
+    days = 7 if window == "7d" else 30
+    selected = _filter_window(pr_rows, days=days, now=now)
+
+    summarized = [summarize_pr_row(pr) for pr in selected]
+    high_risk = [r for r in summarized if r["recommendation"] == "block_pending"]
+
+    previous = _filter_window(pr_rows, days=days * 2, now=now)
+    previous_summarized = [summarize_pr_row(pr) for pr in previous if pr not in selected]
+    previous_high = sum(1 for r in previous_summarized if r["recommendation"] == "block_pending")
+
+    trend = "flat"
+    if len(high_risk) > previous_high:
+        trend = "up"
+    elif len(high_risk) < previous_high:
+        trend = "down"
+
+    hot = Counter(pr.get("repo", "unknown") for pr in selected if summarize_pr_row(pr)["recommendation"] == "block_pending")
+
+    return {
+        "window": window,
+        "highRiskCount": len(high_risk),
+        "highRiskTrend": trend,
+        "hotRepositories": [{"repo": name, "count": count} for name, count in hot.most_common(3)],
+        "links": {
+            "highRiskPrs": _link("dashboard/prs", window=window, risk="high"),
+            "findings": _link("dashboard/findings", window=window, risk="high"),
+            "hotRepositories": _link("dashboard/repos", window=window, sort="risk"),
+        },
+    }

--- a/tests/test_dashboard_risk_panel.py
+++ b/tests/test_dashboard_risk_panel.py
@@ -1,0 +1,59 @@
+import unittest
+from datetime import datetime, timezone
+
+from src.dashboard_risk_panel import build_pr_risk_dashboard
+
+
+class TestDashboardRiskPanel(unittest.TestCase):
+    def test_dashboard_supports_7d_window_and_links(self):
+        now = datetime(2026, 5, 13, 15, 35, tzinfo=timezone.utc)
+        rows = [
+            {
+                "number": 10,
+                "title": "Risky PR",
+                "repo": "mendyraul/reviewpulse",
+                "mergedAt": "2026-05-12T10:00:00Z",
+                "signals": {"test_delta": 90, "churn": 90, "ownership_hotspot": 90, "prior_defect_density": 90},
+            },
+            {
+                "number": 9,
+                "title": "Safe PR",
+                "repo": "mendyraul/reviewpulse",
+                "mergedAt": "2026-05-11T10:00:00Z",
+                "signals": {"test_delta": 5, "churn": 10, "ownership_hotspot": 5, "prior_defect_density": 5},
+            },
+        ]
+
+        panel = build_pr_risk_dashboard(rows, window="7d", now=now)
+
+        self.assertEqual(panel["window"], "7d")
+        self.assertEqual(panel["highRiskCount"], 1)
+        self.assertIn("/dashboard/prs?window=7d&risk=high", panel["links"]["highRiskPrs"])
+
+    def test_dashboard_supports_30d_window_and_hot_repositories(self):
+        now = datetime(2026, 5, 13, 15, 35, tzinfo=timezone.utc)
+        rows = [
+            {
+                "number": 20,
+                "title": "Risky A",
+                "repo": "mendyraul/reviewpulse",
+                "mergedAt": "2026-05-01T10:00:00Z",
+                "signals": {"test_delta": 90, "churn": 90, "ownership_hotspot": 90, "prior_defect_density": 90},
+            },
+            {
+                "number": 21,
+                "title": "Risky B",
+                "repo": "mendyraul/TrackFlights",
+                "mergedAt": "2026-04-25T10:00:00Z",
+                "signals": {"test_delta": 88, "churn": 82, "ownership_hotspot": 90, "prior_defect_density": 91},
+            },
+        ]
+
+        panel = build_pr_risk_dashboard(rows, window="30d", now=now)
+        self.assertEqual(panel["window"], "30d")
+        self.assertEqual(panel["highRiskCount"], 2)
+        self.assertEqual(len(panel["hotRepositories"]), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #32\n\n## What\n- adds  to compute PR risk summary panel data\n- supports 7d/30d windows\n- includes high-risk PR count, trend direction, hot repositories\n- adds deep links to filtered PR/findings/repo views\n- adds unit tests for window behavior + links + hot repository stats\n\n## Validation\n- 