### PR TITLE
docs: done-state UX regression checklist (slice E #54)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,5 @@ Open-source PR review-to-fix loop automation for GitHub + CodeRabbit
 - `docs/slice-b-ingest-handoff.md` — handoff contract for next ingest adapter slices
 - `docs/pr-summary-contract.md` — deterministic PR summary + baseline metrics contract
 - `docs/idempotency-contract.md` — deterministic idempotency-key contract + persistence adapter behavior
+
+- docs/done-state-regression-checklist.md — done-state UX + regression pass checklist (Issue #54).

--- a/docs/done-state-regression-checklist.md
+++ b/docs/done-state-regression-checklist.md
@@ -1,0 +1,27 @@
+# Done-State UX Regression Checklist
+
+Issue: #54
+
+## Done-state UI treatment
+- Done findings must be visually distinct from active findings (`doneState=true` in board payload).
+- Done statuses are limited to `resolved` and `archived` in board flows.
+- Done rows must include timeline events that show who performed the state transition and when.
+
+## Completion confirmation patterns
+- Single-item close requires valid transition path (`new -> triaged -> in_progress -> resolved`).
+- Bulk close from active findings returns `updated`, `skipped`, and `errors` so users can confirm outcomes.
+- Transition action appends timeline entry with `event=status_transition` for traceability.
+
+## Dashboard regression checks
+1. `/dashboard/active` only includes actionable findings.
+2. `/dashboard/done` only includes completed findings.
+3. Owner route and stale flags remain unchanged for non-done records.
+4. PR risk summary still renders with no schema or key changes.
+
+## Quick verification commands
+```bash
+python -m unittest tests/test_board.py
+python -m unittest tests/test_active_findings_board.py
+python -m unittest tests/test_dashboard_routes.py
+python -m unittest tests/test_pr_risk_summary.py
+```


### PR DESCRIPTION
## Summary
- adds  covering done-state UX treatment, completion confirmation, and dashboard regression checks
- links quick verification commands for slice E pass
- updates README docs index

## Notes
- Attempted targeted test run, but repository currently fails due to pre-existing syntax error in  (unclosed ), unrelated to this docs-only PR.

Closes #54